### PR TITLE
fix: add missing overload in cell class `value` method

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -233,6 +233,7 @@ declare namespace XlsxPopulate {
     style(style: Style): Cell;
     value(): string | boolean | number | Date | undefined;
     value(value: string | boolean | number | null | undefined): Cell;
+    value(value: (string | boolean | number | null | undefined | Date)[][]): Cell;
     value(): Range;
     workbook(): Workbook;
     addHorizontalPageBreak(): Cell;


### PR DESCRIPTION
As seen in the [docs](https://www.npmjs.com/package/@eyeseetea/xlsx-populate#ranges), the `.value()` method can be invoked on a Cell object with an array of values:

```js
workbook.sheet(0).cell("A1").value([
    [1, 2, 3],
    [4, 5, 6],
    [7, 8, 9]
]);
```