### PR TITLE
check if vml namespace is already in xml

### DIFF
--- a/lib/Workbook.js
+++ b/lib/Workbook.js
@@ -368,10 +368,16 @@ class Workbook {
                 this._zip.file(`xl/drawings/vmlDrawing${i + 1}.vml`, getVmlDrawingXml(i+1, comments));
 
                 this._contentTypes.add(`/${commentsPath}`, "application/vnd.openxmlformats-officedocument.spreadsheetml.comments+xml");
-                this._contentTypes.addDefault("vml", "application/vnd.openxmlformats-officedocument.vmlDrawing");
             }
         });
 
+        const isVmlInNamespace = this._contentTypes.findByExtension("vml");
+        const hasComments = this._sheets.some(_sheet => Object.keys(_sheet._comments).length > 0);
+        // validate to avoid duplicate vml in the final XML
+        if (hasComments && !isVmlInNamespace) {
+            this._contentTypes.addDefault("vml", "application/vnd.openxmlformats-officedocument.vmlDrawing");
+        }
+        
         // Set the app security to true if a password is set, false if not.
         // this._appProperties.isSecure(!!opts.password);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyeseetea/xlsx-populate",
-  "version": "4.3.0-beta.1",
+  "version": "4.3.1",
   "private": false,
   "description": "Excel XLSX parser/generator written in JavaScript with Node.js and browser support, jQuery/d3-style method chaining, and a focus on keeping existing workbook features and styles in tact.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyeseetea/xlsx-populate",
-  "version": "4.3.0",
+  "version": "4.3.0-beta.1",
   "private": false,
   "description": "Excel XLSX parser/generator written in JavaScript with Node.js and browser support, jQuery/d3-style method chaining, and a focus on keeping existing workbook features and styles in tact.",
   "license": "MIT",


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8697qpqp6

### :memo: Implementation

For every sheet with notes the `vml` definition was being added in the `[Content_Types].xml` file. This was generating an error in Microsoft excel. 

Now this definition is only included if there are comments in the sheet and if `vml` does not already exist in the xml.

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/034ef453-4ba1-4daf-bebc-5df27d77d022

### :fire: Notes to the tester

#8697qpqp6