### PR TITLE
add support for non shared formulas

### DIFF
--- a/README.md
+++ b/README.md
@@ -3139,8 +3139,8 @@ Set the comment on the cell with the given address.
 | [opts.text] | <code>string</code> | The comment text to set. |
 | [opts.width] | <code>string</code> | Comment box width. |
 | [opts.height] | <code>string</code> | Comment box height. |
-| [opts.horizontalAlignment] | <code>string</code> | Comment horizontalAlignment. |
 | [opts.textAlign] | <code>string</code> | Comment textAlign. |
+| [opts.horizontalAlignment] | <code>string</code> | Comment horizontalAlignment. |
 
 <a name="Sheet+conditionalFormatting"></a>
 

--- a/README.md
+++ b/README.md
@@ -1241,8 +1241,8 @@ Set or clear the comment on the cell.
 | [opts.text] | <code>string</code> | The comment text to set. |
 | [opts.width] | <code>string</code> | Comment box width. |
 | [opts.height] | <code>string</code> | Comment box height. |
-| [opts.horizontalAlignment] | <code>string</code> | Comment horizontalAlignment |
 | [opts.textAlign] | <code>string</code> | Comment text Align. |
+| [opts.horizontalAlignment] | <code>string</code> | Comment horizontalAlignment |
 
 <a name="Cell+dataValidation"></a>
 
@@ -3139,8 +3139,8 @@ Set the comment on the cell with the given address.
 | [opts.text] | <code>string</code> | The comment text to set. |
 | [opts.width] | <code>string</code> | Comment box width. |
 | [opts.height] | <code>string</code> | Comment box height. |
-| [opts.textAlign] | <code>string</code> | Comment textAlign. |
 | [opts.horizontalAlignment] | <code>string</code> | Comment horizontalAlignment. |
+| [opts.textAlign] | <code>string</code> | Comment textAlign. |
 
 <a name="Sheet+conditionalFormatting"></a>
 

--- a/README.md
+++ b/README.md
@@ -1241,8 +1241,8 @@ Set or clear the comment on the cell.
 | [opts.text] | <code>string</code> | The comment text to set. |
 | [opts.width] | <code>string</code> | Comment box width. |
 | [opts.height] | <code>string</code> | Comment box height. |
-| [opts.textAlign] | <code>string</code> | Comment text Align. |
 | [opts.horizontalAlignment] | <code>string</code> | Comment horizontalAlignment |
+| [opts.textAlign] | <code>string</code> | Comment text Align. |
 
 <a name="Cell+dataValidation"></a>
 
@@ -3747,5 +3747,3 @@ https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.p
 | topLeftCell | <code>string</code> |  | Top Left Visible Cell. Location of the top left visible cell in the bottom right pane (when in Left-To-Right mode). |
 | xSplit | <code>number</code> |  | (Horizontal Split Position) Horizontal position of the split, in 1/20th of a point; 0 (zero) if none. If the pane is frozen, this value indicates the number of columns visible in the top pane. |
 | ySplit | <code>number</code> |  | (Vertical Split Position) Vertical position of the split, in 1/20th of a point; 0 (zero) if none. If the pane is frozen, this value indicates the number of rows visible in the left pane. |
-
-

--- a/README.md
+++ b/README.md
@@ -3747,3 +3747,4 @@ https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.p
 | topLeftCell | <code>string</code> |  | Top Left Visible Cell. Location of the top left visible cell in the bottom right pane (when in Left-To-Right mode). |
 | xSplit | <code>number</code> |  | (Horizontal Split Position) Horizontal position of the split, in 1/20th of a point; 0 (zero) if none. If the pane is frozen, this value indicates the number of columns visible in the top pane. |
 | ySplit | <code>number</code> |  | (Vertical Split Position) Vertical position of the split, in 1/20th of a point; 0 (zero) if none. If the pane is frozen, this value indicates the number of rows visible in the left pane. |
+

--- a/lib/Cell.js
+++ b/lib/Cell.js
@@ -471,6 +471,7 @@ class Cell {
      * @param {number} id - The shared formula index.
      * @param {string} [formula] - The formula (if the reference cell).
      * @param {string} [sharedRef] - The address of the shared range (if the reference cell).
+     * @param {boolean} [isShared] - If `true`, generates the formula as a shared formula
      * @returns {undefined}
      * @ignore
      */

--- a/lib/Cell.js
+++ b/lib/Cell.js
@@ -474,10 +474,32 @@ class Cell {
      * @returns {undefined}
      * @ignore
      */
-    setSharedFormula(id, formula, sharedRef) {
+    setSharedFormula(id, formula, sharedRef, isShared = true) {
         this.clear();
 
-        this._formulaType = "shared";
+        if (isShared) {
+            this._formulaType = "shared";
+        } else {
+            /*
+                by default xlsx-populate always generates formulas as "shared formulas"
+                <c r="E4">
+                    // shared, ref and si attributes are always added            
+                    <f t="shared" ref="E4:E1024" si="3">FORMULA</f>
+                </c>
+
+                for simple formulas excel is not going to complain, but with complex ones
+                you can get the errors:
+
+                Removed Records: Formula from /xl/worksheets/sheet3.xml part
+                Removed Records: Shared formula from /xl/worksheets/sheet3.xml part
+
+                Setting formulaType to normal generates this:
+                <c r="E3">
+                    <f>complex_formula</f>
+                </c>
+             */
+            this._formulaType = "normal";
+        }
         this._sharedFormulaId = id;
         this._formula = formula;
         this._formulaRef = sharedRef;
@@ -677,4 +699,3 @@ module.exports = Cell;
     <v>2</v>
 </c>
 */
-

--- a/lib/Range.js
+++ b/lib/Range.js
@@ -125,6 +125,11 @@ class Range {
             .case(() => {
                 return this.startCell().getSharedRefFormula();
             })
+            .case('object', options => {
+                const { formula, shared } = options;
+                this.forEach(cell => cell.setSharedFormula(undefined, formula, undefined, shared));
+                return this;
+            })
             .case('string', formula => {
                 const sharedFormulaId = this.sheet().incrementMaxSharedFormulaId();
                 this.forEach((cell, ri, ci) => {

--- a/lib/Range.js
+++ b/lib/Range.js
@@ -118,6 +118,9 @@ class Range {
      *//**
      * Sets the shared formula in the range. The formula will be translated for each cell.
      * @param {string} formula - The formula to set.
+     * @param {object} [options] - Object specifying the formula configuration:
+     *   - `formula` {string} The formula to set.
+     *   - `shared` {boolean} Whether the formula should be generated as shared.
      * @returns {Range} The range.
      */
     formula() {

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -280,6 +280,7 @@ declare namespace XlsxPopulate {
     forEach(callback: Function): Range;
     formula(): string | undefined;
     formula(formula: string): Range;
+    formula(options: { formula: string, shared: boolean }): Range;
     map(callback: Function): any[][];
     merged(): boolean;
     merged(merged: boolean): Range;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyeseetea/xlsx-populate",
-  "version": "4.3.1-beta.1",
+  "version": "4.3.2-beta.1",
   "private": false,
   "description": "Excel XLSX parser/generator written in JavaScript with Node.js and browser support, jQuery/d3-style method chaining, and a focus on keeping existing workbook features and styles in tact.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eyeseetea/xlsx-populate",
-  "version": "4.3.1",
+  "version": "4.3.1-beta.1",
   "private": false,
   "description": "Excel XLSX parser/generator written in JavaScript with Node.js and browser support, jQuery/d3-style method chaining, and a focus on keeping existing workbook features and styles in tact.",
   "license": "MIT",


### PR DESCRIPTION
### :pushpin: References

- **Issue:** Closes https://app.clickup.com/t/86991ktdr

### :memo: Implementation

By default formulas are generated as "shared formulas":

```xml
<c r="E4">
  // shared, ref and si attributes are always added            
  <f t="shared" ref="E4:E1024" si="3">FORMULA</f>
</c>
```

for simple formulas excel is not going to complain, but with complex ones you can get these errors:

![image](https://github.com/user-attachments/assets/ec852be8-6b26-4085-9837-9bfd2b404e1b)

In this PR I'm adding the `formulaType` "normal" to avoid excel errors

```xml
<c r="E4">
  <f>FORMULA</f>
</c>
```

Both works without any problem in libre office.

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester

Can you please help me publishing a new version so I can test it on bulk load? @adrianq @MiquelAdell 
